### PR TITLE
Adding .conf to CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,8 @@ CU_SET_PATH("CMAKE_MOD_STARTGUILD_DIR" "${CMAKE_CURRENT_LIST_DIR}")
 
 AC_ADD_SCRIPT("${CMAKE_CURRENT_LIST_DIR}/src/mod_startguild.cpp")
 
+AC_ADD_CONFIG_FILE("${CMAKE_CURRENT_LIST_DIR}/conf/mod_startguild.conf.dist")
+
 AC_ADD_SCRIPT_LOADER("StartGuild" "${CMAKE_CURRENT_LIST_DIR}/src/loader_startguild.h")
 
 CU_ADD_HOOK(AFTER_WORLDSERVER_CMAKE "${CMAKE_CURRENT_LIST_DIR}/src/cmake/after_ws_install.cmake")


### PR DESCRIPTION
The module does not recognize the configuration file. So in the worldserver, it shows some messages and doesn't add the players in the respective brotherhoods.