### PR TITLE
Fix on level invite

### DIFF
--- a/src/mod_starterguild.cpp
+++ b/src/mod_starterguild.cpp
@@ -9,9 +9,16 @@ void StarterGuild::OnLogin(Player* player)
             ChatHandler(player->GetSession()).SendSysMessage("This server is running the |cff4CFF00StarterGuild |rmodule.");
         }
 
-        uint8 level = sConfigMgr->GetOption<uint8>("StarterGuild.Level", 0);
+    }
+}
 
-        if (level > 0 && player->GetLevel() == level && !player->GetGuild())
+void StarterGuild::OnLevelChanged(Player * player, uint8 previousLevel)
+{
+    if (sConfigMgr->GetOption<bool>("StarterGuild.Enable", true))
+    {
+        auto level = sConfigMgr->GetOption<uint8>("StarterGuild.Level", 0);
+
+        if (level > 0 && (player->GetLevel() == level || (player->GetLevel() > level && previousLevel < level)))
         {
             addPlayerToGuild(player);
         }
@@ -20,7 +27,7 @@ void StarterGuild::OnLogin(Player* player)
 
 void StarterGuild::OnFirstLogin(Player* player)
 {
-    if (sConfigMgr->GetOption<bool>("StarterGuild.Enable", true) && (sConfigMgr->GetOption<uint8>("StarterGuild.Level", 0) == 0))
+    if (sConfigMgr->GetOption<bool>("StarterGuild.Enable", true) && ((sConfigMgr->GetOption<uint8>("StarterGuild.Level", 0) == 0)||player->GetLevel()>=sConfigMgr->GetOption<uint8>("StarterGuild.Level", 0)))
     {
         addPlayerToGuild(player);
     }

--- a/src/mod_starterguild.cpp
+++ b/src/mod_starterguild.cpp
@@ -18,7 +18,7 @@ void StarterGuild::OnLevelChanged(Player * player, uint8 previousLevel)
     {
         auto level = sConfigMgr->GetOption<uint8>("StarterGuild.Level", 0);
 
-        if (level > 0 && (player->GetLevel() == level || (player->GetLevel() > level && previousLevel < level)))
+        if (level > 0 && !player->GetGuild() && (player->GetLevel() == level || (player->GetLevel() > level && previousLevel < level)))
         {
             addPlayerToGuild(player);
         }

--- a/src/mod_starterguild.h
+++ b/src/mod_starterguild.h
@@ -71,6 +71,8 @@ public:
     void OnLogin(Player* player) override;
     void OnFirstLogin(Player* player) override;
     void addPlayerToGuild(Player* player);
+    void OnLevelChanged(Player * player, uint8 previousLevel) override;
+
 };
 
 void AddStarterGuildScripts()


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/mod-starter-guild/issues/18
- adiitonally fixes "DeathKnight Edge Case" where Invite to Guild is not issued to a new char, if he is created with a higher level then the configured invite level 



## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- build without errors
- manually tested ingame
- 


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. see  https://github.com/azerothcore/mod-starter-guild/issues/18
2.
3.
