### PR TITLE
fix: Welcome text fmt crash

### DIFF
--- a/src/mod_starterguild.cpp
+++ b/src/mod_starterguild.cpp
@@ -44,11 +44,13 @@ void StarterGuild::addPlayerToGuild(Player* player)
 
             // Inform the player they have joined the guild
             std::string welcome_text = player->GetTeamId() == TEAM_ALLIANCE ? GUILD_WELCOME_TEXT_ALLIANCE : GUILD_WELCOME_TEXT_HORDE;
+            std::string guild_name = player->GetGuildName();
+            std::string player_name = player->GetPlayerName();
 
             welcome_text = fmt::format(
                 fmt::runtime(welcome_text),
-                fmt::arg("GUILD", player->GetGuildName()),
-                fmt::arg("PLAYER", player->GetPlayerName())
+                fmt::arg("GUILD", guild_name),
+                fmt::arg("PLAYER", player_name)
             );
 
             ChatHandler(player->GetSession()).SendSysMessage(welcome_text);


### PR DESCRIPTION

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:

The previous PR didn't solve the crash

- https://github.com/azerothcore/mod-starter-guild/pull/26

TLDR: rvalue was being passed that goes out of scope immediately

> The crash occurs because fmt::arg() is receiving temporary string values that are destroyed before the fmt::format() call completes. When player->GetGuildName() and player->GetPlayerName() return temporary strings, the fmt::arg() creates references to them, but they go out of scope immediately.

crash stack: https://gist.github.com/sogladev/7f7e238d673759d1dc4ce4474a303e7c


## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- 
- 


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1.
2.
3.
